### PR TITLE
Convert plain array to TypoScript array for cObject usage

### DIFF
--- a/Classes/ViewHelpers/CObjectConfigViewHelper.php
+++ b/Classes/ViewHelpers/CObjectConfigViewHelper.php
@@ -55,7 +55,7 @@ class Tx_PtExtbase_ViewHelpers_CObjectConfigViewHelper extends Tx_Fluid_Core_Vie
 			Tx_PtExtbase_Div::getCobj()->start($data);
 		}
 
-		return Tx_PtExtbase_Div::getCobj()->cObjGetSingle($config['_typoScriptNodeValue'], $config);
+		return Tx_PtExtbase_Div::getCobj()->cObjGetSingle($config['_typoScriptNodeValue'], Tx_Extbase_Utility_TypoScript::convertPlainArrayToTypoScriptArray($config));
 	}
 	
 }


### PR DESCRIPTION
When calling cObjectGetSingle() we need to pass a normal TypoScript array rather than the plain array that Extbase creates by removing periods (ie. 10.) and adding _typoScriptNodeValue keys.
