### PR TITLE
[BUGFIX] Adjust constructor function to current Repository class

### DIFF
--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -37,7 +37,7 @@ class Tx_PtExtbase_Domain_Repository_PageRepository extends Tx_Extbase_Persisten
 	 * Sets the respect storage page to false.
 	 * @param Tx_Extbase_Object_ObjectManagerInterface $objectManager
 	 */
-	public function __construct(Tx_Extbase_Object_ObjectManagerInterface $objectManager = NULL) {
+	public function __construct(Tx_Extbase_Object_ObjectManagerInterface $objectManager) {
 		 parent::__construct($objectManager);
 		 $this->defaultQuerySettings = new Tx_Extbase_Persistence_Typo3QuerySettings();
 		 $this->defaultQuerySettings->setRespectStoragePage(FALSE);

--- a/Classes/Domain/Repository/SysLanguageRepository.php
+++ b/Classes/Domain/Repository/SysLanguageRepository.php
@@ -36,7 +36,7 @@ class Tx_PtExtbase_Domain_Repository_SysLanguageRepository extends Tx_Extbase_Pe
 	 * Sets the respect storage page to false.
 	 * @param Tx_Extbase_Object_ObjectManagerInterface $objectManager
 	 */
-	public function __construct(Tx_Extbase_Object_ObjectManagerInterface $objectManager = NULL) {
+	public function __construct(Tx_Extbase_Object_ObjectManagerInterface $objectManager) {
 		 parent::__construct($objectManager);
 		 $this->defaultQuerySettings = new Tx_Extbase_Persistence_Typo3QuerySettings();
 		 $this->defaultQuerySettings->setRespectStoragePage(FALSE);


### PR DESCRIPTION
Same as for the yag repository. The core class has changed so the classes have to be adjusted.
