### PR TITLE
TASK: Tree could contain deleted nodes if necessary

### DIFF
--- a/Classes/Tree/NodeRepository.php
+++ b/Classes/Tree/NodeRepository.php
@@ -160,6 +160,11 @@ class Tx_PtExtbase_Tree_NodeRepository
                   ->setRespectSysLanguage(false)
                   ->setIgnoreEnableFields(!$respectEnableFields);
 
+        // It is not possible to set IgnoreEnableFields to false and includeDeleted to true
+        if($this->treeContext->isIncludeDeleted() && !$respectEnableFields) {
+            $query->getQuerySettings()->setIncludeDeleted(true);
+        }
+
 
         $nameSpaceConstraint = $query->equals('namespace', $namespace);
 

--- a/Classes/Tree/TreeContext.php
+++ b/Classes/Tree/TreeContext.php
@@ -36,7 +36,10 @@ class Tx_PtExtbase_Tree_TreeContext implements \TYPO3\CMS\Core\SingletonInterfac
      */
     protected $writable = false;
 
-
+    /**
+     * @var bool
+     */
+    protected $includeDeleted = false;
 
     /**
      * @return void
@@ -78,6 +81,23 @@ class Tx_PtExtbase_Tree_TreeContext implements \TYPO3\CMS\Core\SingletonInterfac
         return $this->writable;
     }
 
+
+    /**
+     * @return bool
+     */
+    public function isIncludeDeleted()
+    {
+        return $this->includeDeleted;
+    }
+
+
+    /**
+     * @param bool $includeDeleted
+     */
+    public function setIncludeDeleted($includeDeleted)
+    {
+        $this->includeDeleted = $includeDeleted;
+    }
 
 
     /**


### PR DESCRIPTION
Because the ignoreEnableFields option does not consider deleted tree nodes it should be possible to set the includeDeleted option for trees that should contain all (deleted/hidden/disabled ...) nodes