### PR TITLE
BUGFIX: warning array_key_exists() expects parameter 2 to be array, null given

### DIFF
--- a/Classes/Configuration/AbstractConfigurationBuilder.php
+++ b/Classes/Configuration/AbstractConfigurationBuilder.php
@@ -140,7 +140,10 @@ abstract class AbstractConfigurationBuilder implements ConfigurationBuilderInter
 
         $tsKey = array_key_exists('tsKey', $this->configurationObjectSettings[$configurationName]) ? $this->configurationObjectSettings[$configurationName]['tsKey'] : $configurationName;
         if ($tsKey) {
-            $settings = array_key_exists($tsKey, $this->settings) ? $this->settings[$tsKey] : [];
+            $settings = [];
+            if (is_array($this->settings) && array_key_exists($tsKey, $this->settings)) {
+                $settings = $this->settings[$tsKey];
+            }
         } else {
             $settings = $this->settings;
         }


### PR DESCRIPTION
Fixes a bug, where array settings is not setted empty, when settings is not an array for some reason